### PR TITLE
fix(zscaler_ai_guard): return 400 on guardrail block

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -190,7 +190,7 @@ class ZscalerAIGuard(CustomGuardrail):
             if zscaler_ai_guard_result and zscaler_ai_guard_result.get("action") == "BLOCK":
                 blocking_info = zscaler_ai_guard_result.get("zscaler_ai_guard_response")
                 error_message = f"Content blocked by Zscaler AI Guard: {self.extract_blocking_info(blocking_info)}"
-                raise Exception(error_message)
+                raise HTTPException(status_code=400, detail={"error": error_message})
         except Exception as e:
             verbose_proxy_logger.error("ZscalerAIGuard: Failed to apply guardrail: %s", str(e))
             raise e
@@ -340,6 +340,8 @@ class ZscalerAIGuard(CustomGuardrail):
         try:
             response = await self._send_request(zscaler_ai_guard_url, extra_headers, data)
             return self._handle_response(response, direction)
+        except HTTPException:
+            raise
         except Exception as e:
             verbose_proxy_logger.error(f"{e}. Blocking request.")
             user_facing_error = self._create_user_facing_error(f"{str(e)}")

--- a/tests/guardrails_tests/test_zscaler_ai_guard.py
+++ b/tests/guardrails_tests/test_zscaler_ai_guard.py
@@ -337,3 +337,30 @@ async def test_should_omit_policy_id_when_zero_or_negative():
         call_args = mock_send.call_args
         data = call_args[0][2]  # Third positional arg is data
         assert "policyId" not in data
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard.ZscalerAIGuard.make_zscaler_ai_guard_api_call",
+    new_callable=AsyncMock,
+)
+async def test_apply_guardrail_block_raises_400(mock_api_call):
+    """
+    When the guardrail returns BLOCK, apply_guardrail must raise HTTPException
+    with status_code=400 (not 500).
+    """
+    mock_api_call.return_value = {
+        "action": "BLOCK",
+        "zscaler_ai_guard_response": {
+            "transactionId": "tx-123",
+            "detectorResponses": {"detector1": {"action": "BLOCK"}},
+        },
+    }
+    guardrail = ZscalerAIGuard(api_key="test_key", policy_id=1)
+    inputs = {"texts": ["inject malicious content"]}
+    request_data = {}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await guardrail.apply_guardrail(inputs, request_data, "request")
+
+    assert exc_info.value.status_code == 400
+    assert "blocked" in exc_info.value.detail["error"].lower()


### PR DESCRIPTION
## Relevant issues

Currently, when input/LLm response got blocked by zscaler guardrail, it return http_code:500, change to 400


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ Y] I have added meaningful tests
- [ Y] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [Y ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
<img width="778" height="188" alt="image" src="https://github.com/user-attachments/assets/9f3b6a86-857d-4d8d-92e2-a719464707de" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes
